### PR TITLE
refactoring

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-swap_size: '4096'
+swap_size: '{{ ansible_memtotal_mb }}'
 swap_path: /swapfile
 swap_swappiness: '10'
 swap_vfs_cache_pressure: '50'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-swap_size: '{{ ansible_memtotal_mb }}'
+swap_size: '4096'
 swap_path: /swapfile
-swap_swappiness: 10
-swap_vfs_cache_pressure: 50
+swap_swappiness: '10'
+swap_vfs_cache_pressure: '50'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,12 @@
-- block:
+- when: not (ansible_swaptotal_mb | int) + 1 == swap_size | int
+  block:
     - name: disable swap
       shell: test -f {{ swap_path }} && swapoff {{ swap_path }} || true
       tags:
         - swap
 
     - name: create file
-      command: 'dd if=/dev/zero of={{ swap_path }} bs=1M count={{ swap_size }}'
+      command: 'fallocate -l {{ swap_size }}M {{ swap_path }}'
       tags:
         - swap
 
@@ -13,7 +14,6 @@
       command: 'mkswap {{ swap_path }}'
       tags:
         - swap
-  when: not (ansible_swaptotal_mb | int) + 1 == swap_size | int
 
 - name: fix permissions
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
   tags:
     - swap
 
-- name: add swapfile to fstab
+- name: mount swap
   mount:
     src: "{{ swap_path }}"
     path: swap

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,4 @@
-- when: not (ansible_swaptotal_mb | int) + 1 == swap_size | int
+- when: (ansible_swaptotal_mb | int) + 1 != swap_size | int
   block:
     - name: disable swap
       shell: test -f {{ swap_path }} && swapoff {{ swap_path }} || true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,36 +1,21 @@
-- name: check swap
-  register: swap_stat
-  stat:
-    path: '{{ swap_path }}'
-  tags:
-    - swap
+- block:
+    - name: disable swap
+      shell: test -f {{ swap_path }} && swapoff {{ swap_path }} || true
+      tags:
+        - swap
 
-- name: fact current
-  set_fact:
-    swap_current: '{{ (swap_stat.stat.size | default(0) / 1024 / 1024) | int }}'
-  tags:
-    - swap
+    - name: create file
+      command: 'dd if=/dev/zero of={{ swap_path }} bs=1M count={{ swap_size }}'
+      tags:
+        - swap
 
-- name: fact change
-  set_fact:
-    swap_change: '{{ swap_stat.stat.exists and swap_current != swap_size }}'
-  tags:
-    - swap
-
-- name: disable swap
-  when: swap_change
-  command: 'swapoff {{ swap_path }}'
-  tags:
-    - swap
-
-- name: create file
-  when: swap_change
-  command: 'fallocate -l {{ swap_size }}M {{ swap_path }}'
-  tags:
-    - swap
+    - name: format file
+      command: 'mkswap {{ swap_path }}'
+      tags:
+        - swap
+  when: not (ansible_swaptotal_mb | int) + 1 == swap_size | int
 
 - name: fix permissions
-  when: swap_change
   file:
     path: '{{ swap_path }}'
     owner: root
@@ -39,15 +24,18 @@
   tags:
     - swap
 
-- name: format file
-  when: swap_change
-  command: 'mkswap {{ swap_path }}'
+- name: add swapfile to fstab
+  mount:
+    src: "{{ swap_path }}"
+    path: swap
+    fstype: swap
+    state: present
   tags:
     - swap
 
 - name: enable swap
-  when: swap_change
-  command: 'swapon {{ swap_path }}'
+  command: 'swapon -a'
+  changed_when: False
   tags:
     - swap
 


### PR DESCRIPTION
- switch to `dd` because reduce size with `fallocate` was not working
- use `ansible_swaptotal_mb` instead of some custom facts
- use ` swapon -a` instead of `swapon {{ swap_path }}` because this throws an error if swap is already enabled for the given file
- add fstab entry (works without markers)